### PR TITLE
Remove link to Community

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,6 @@
 	<nav>	
 			<ul>
 				<li><a href="https://twitter.com/owntracks">Twitter</a></li>
-				<li><a href="https://community.owntracks.org">Community</a></li>
 				<li><a href="https://github.com/owntracks">Github</a></li>
 			</ul>
 		</nav>


### PR DESCRIPTION
I am not sure if this is the right place to do this, but the link is broken and apparently was removed from apps as well.

By the way, it would be nice to have a prominent link to the documentation either on bottom or top.