### PR TITLE
Add link to documentation in the bottom navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
 	<nav>	
 			<ul>
 				<li><a href="https://fosstodon.org/@owntracks">Mastodon</a></li>
+				<li><a href="https://owntracks.org/booklet/">Documentation</a></li>
 				<li><a href="https://github.com/owntracks/talk">Talk</a></li>
 				<li><a href="https://github.com/owntracks">Github</a></li>
 				<li><a href="https://liberapay.com/OwnTracks.org/donate">Donate</a></li>


### PR DESCRIPTION
This adds a link to the booklet documentation in the navigation boxes at the bottom of the page.

There is already a link within a paragraph on the page that says

> Afterwards you can connect it to an existing server straight away or follow the guide in our Booklet to set up your own. 

I think that noticing that link within a paragraph and knowing that `Booklet` means documentation may make it hard for users to realize that there is a documentation site.

What would you think about adding a block to the navigation at the bottom which adds a link to the doc site?